### PR TITLE
fix: set window can get focus

### DIFF
--- a/src/dbusscreensaver.cpp
+++ b/src/dbusscreensaver.cpp
@@ -552,7 +552,9 @@ void DBusScreenSaver::onScreenAdded(QScreen *s)
     w->setPosition(s->availableGeometry().center());
     w->setScreen(s);
     // kwin 下不可添加Dialog标志，否则会导致窗口只能显示出一个，然而，在 deepin-wm 上使用其它窗口类型时又会有动画
-    w->setFlags(Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint | Qt::Drawer | Qt::WindowDoesNotAcceptFocus);
+    // 不要添加Qt::WindowDoesNotAcceptFocus，以防止deepin-kwin在进入到显示桌面模式时触发屏幕保护
+    // 但是却没有退出显示桌面模式，这样将会导致dock显示在屏幕保护窗口的上方
+    w->setFlags(Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint | Qt::Drawer);
     w->create();
 
     m_windowMap[s] = w;


### PR DESCRIPTION
Fix the window display in dock below
https://github.com/linuxdeepin/internal-discussion/issues/1710

修复单屏时屏幕保护窗口在显示桌面模式中会显示在dock下方
设置窗口为接收焦点的类型，这样当kwin中发现新窗口想要获取焦点时就会退出显示桌面状态