### PR TITLE
fix: can not quit by keyboard on wayland

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-screensaver (5.0.13) stable; urgency=medium
+
+  * update V23 baseline version.
+
+ -- Deepin Packages Builder <packages@deepin.com>  Mon, 15 Aug 2022 10:56:33 +0800
+
 deepin-screensaver (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: deepin-screensaver
 Section: devel
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
-Build-Depends: debhelper (>=9), qtbase5-dev, qtdeclarative5-dev, libqt5x11extras5-dev, libx11-dev, libxss-dev, libxext-dev, pkg-config, qml-module-qt-labs-platform
+Build-Depends: debhelper (>=9), qtbase5-dev, qtdeclarative5-dev, libqt5x11extras5-dev, libx11-dev, libxss-dev, libxext-dev, libdframeworkdbus-dev, pkg-config, qml-module-qt-labs-platform
 Standards-Version: 3.9.8
 
 Package: deepin-screensaver

--- a/src/dbusscreensaver.h
+++ b/src/dbusscreensaver.h
@@ -21,6 +21,8 @@
 #ifndef DBUSSCREENSAVER_H
 #define DBUSSCREENSAVER_H
 
+#include <com_deepin_sessionmanager.h>
+
 #include <QObject>
 #include <QProcess>
 #include <QDir>
@@ -28,6 +30,7 @@
 #include <QSettings>
 #include <QDBusMessage>
 #include <QScreen>
+#include <QAtomicInteger>
 
 class ScreenSaverWindow;
 class X11EventFilter;
@@ -85,6 +88,10 @@ private:
     void onScreenAdded(QScreen *s);
     void cleanWindow(ScreenSaverWindow *w);
 
+    void XGrabKeyBoard();
+    void XUnGrabKeyBoard();
+    void onLockedChanged(const bool locked);
+
     QList<QDir> m_resourceDirList;
     QStringList m_resourceList;
 
@@ -100,6 +107,9 @@ private:
     QTimer m_autoQuitTimer;
     QSettings m_settings;
     QScopedPointer<X11EventFilter> x11event;
+
+    com::deepin::SessionManager *m_sessionManagerInter = nullptr;
+    QAtomicInteger<bool> m_grabKeyboard = false;
 };
 
 #endif // DBUSSCREENSAVER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ int main(int argc, char *argv[])
 {
     auto envType = qEnvironmentVariable("XDG_SESSION_TYPE");
     if (envType.contains("wayland")) {
+        qInfo() << QDateTime::currentDateTime().toString() << "notes:change wayland to xcb for QT_QPA_PLATFORM.";
         qputenv("QT_QPA_PLATFORM", "xcb");
     }
 

--- a/src/screensaverview.cpp
+++ b/src/screensaverview.cpp
@@ -27,6 +27,7 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QDebug>
+#include <QDateTime>
 
 Q_GLOBAL_STATIC(QQmlEngine, qmlEngineGlobal)
 
@@ -107,6 +108,7 @@ bool ScreenSaverView::event(QEvent *event)
     case QEvent::TouchCancel:
     case QEvent::KeyPress:
     case QEvent::KeyRelease:
+        qInfo() << QDateTime::currentDateTime().toString() << "recive input evnet and will quit:" << event->type();
         emit inputEvent(event->type());
         break;
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,7 +1,7 @@
 TARGET = deepin-screensaver
 QT += gui dbus quick x11extras
 CONFIG += c++11 link_pkgconfig
-PKGCONFIG += x11 xscrnsaver xext
+PKGCONFIG += x11 xscrnsaver xext xcb dframeworkdbus
 
 SOURCES += \
     $$PWD/main.cpp \


### PR DESCRIPTION
on the wayland environment,applications cannot recive keyboard events.
exit the screensaver by forcibly grabbing the keyboard.

Log: fix can not quit by keyboard on wayland