### PR TITLE
fix: Custom image screensaver crash problem

### DIFF
--- a/customscreensaver/deepin-custom-screensaver/src/slideshowscreensaver.cpp
+++ b/customscreensaver/deepin-custom-screensaver/src/slideshowscreensaver.cpp
@@ -65,7 +65,7 @@ void SlideshowScreenSaver::onUpdateImage()
         return;
 
     if (m_shuffle) {
-        m_currentImage = int(QRandomGenerator::global()->generate() % uint(m_imagefiles.count()) - 1);
+        m_currentImage = int(QRandomGenerator::global()->generate() % uint(m_imagefiles.count()));
     } else {
         if (m_currentImage < m_imagefiles.count() - 1)
             m_currentImage++;


### PR DESCRIPTION
 When the image is fetched, it randomly reaches -1, which triggers the assertion

Log: fix that custom image screensaver crash problem
Bug: https://pms.uniontech.com/bug-view-167377.html