### PR TITLE
fix: Multiple custom screensaver Settings coexist

### DIFF
--- a/src/customconfig.cpp
+++ b/src/customconfig.cpp
@@ -5,6 +5,7 @@
 #include "customconfig.h"
 #include "screensaversettingdialog.h"
 #include "utils.h"
+#include "singleapplication.h"
 
 #include <QApplication>
 
@@ -14,6 +15,11 @@ CustomConfig::CustomConfig(QObject *parent) : QObject(parent)
 
 CustomConfig::~CustomConfig()
 {
+    if (m_singleApp) {
+        delete m_singleApp;
+        m_singleApp = nullptr;
+    }
+
     if (m_settingDialiog) {
         delete m_settingDialiog;
         m_settingDialiog = nullptr;
@@ -24,6 +30,12 @@ bool CustomConfig::startCustomConfig(const QString &name)
 {
     if (!Utils::hasConfigFile(name))
         return false;
+
+    if (!m_singleApp)
+        m_singleApp = new SingleApplication();
+
+    if (!m_singleApp->setSingleInstance("ScreenSaverSettingDialog"))
+        return true;
 
     if (m_settingDialiog)
         delete m_settingDialiog;

--- a/src/customconfig.h
+++ b/src/customconfig.h
@@ -7,6 +7,7 @@
 
 #include <QObject>
 
+class SingleApplication;
 class ScreenSaverSettingDialog;
 class CustomConfig : public QObject
 {
@@ -17,7 +18,8 @@ public:
 
     bool startCustomConfig(const QString &name);
 private:
-    ScreenSaverSettingDialog *m_settingDialiog {nullptr};
+    ScreenSaverSettingDialog *m_settingDialiog { nullptr };
+    SingleApplication *m_singleApp { nullptr };
 };
 
 #endif // DBUSCUSTOMCONFIG_H

--- a/src/singleapplication.cpp
+++ b/src/singleapplication.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "singleapplication.h"
+
+#include <QFile>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QStandardPaths>
+
+SingleApplication::SingleApplication()
+{
+    m_localServer = new QLocalServer;
+}
+
+SingleApplication::~SingleApplication()
+{
+    if (m_localServer){
+        m_localServer->removeServer(m_localServer->serverName());
+        m_localServer->close();
+        delete m_localServer;
+        m_localServer = nullptr;
+    }
+}
+
+QString SingleApplication::userServerName(const QString &key)
+{
+    QString userKey = QString("%1/%2").arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation), key);
+    if (userKey.isEmpty()) {
+        userKey = QString("%1/%2").arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation), key);
+    }
+    return userKey;
+}
+
+bool SingleApplication::setSingleInstance(const QString &key)
+{
+    QString userKey = userServerName(key);
+
+    QLocalSocket localSocket;
+    localSocket.connectToServer(userKey);
+
+    // if connect success, another instance is running.
+    bool result = localSocket.waitForConnected(1000);
+
+    if (result)
+        return false;
+
+    m_localServer->removeServer(userKey);
+
+    bool f = m_localServer->listen(userKey);
+    if (f) {
+        if(m_localServer->serverError()== QAbstractSocket::AddressInUseError
+                && QFile::exists(m_localServer->serverName())){
+            QFile::remove(m_localServer->serverName());
+            m_localServer->listen(userKey);
+        }
+    }
+
+    return f;
+}

--- a/src/singleapplication.h
+++ b/src/singleapplication.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SINGLEAPPLICATION_H
+#define SINGLEAPPLICATION_H
+
+#include <QtGlobal>
+
+#include <DApplication>
+
+QT_BEGIN_NAMESPACE
+class QLocalServer;
+class QLocalSocket;
+QT_END_NAMESPACE
+
+DWIDGET_USE_NAMESPACE
+
+class SingleApplication : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SingleApplication();
+    ~SingleApplication();
+
+    static QString userServerName(const QString &key);
+
+public:
+    bool setSingleInstance(const QString &key);
+
+private:
+    QLocalServer *m_localServer;
+};
+
+#endif // SINGLEAPPLICATION_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -15,7 +15,8 @@ SOURCES += \
     $$PWD/screensaversettingdialog.cpp \
     $$PWD/selectpathwidget.cpp \
     $$PWD/customconfig.cpp \
-    $$PWD/utils.cpp
+    $$PWD/utils.cpp \
+    singleapplication.cpp
 
 HEADERS += \
     $$PWD/screensaverwindow.h \
@@ -26,7 +27,8 @@ HEADERS += \
     $$PWD/truncatelineedit.h \
     $$PWD/screensaversettingdialog.h \
     $$PWD/customconfig.h \
-    $$PWD/utils.h
+    $$PWD/utils.h \
+    $$PWD/singleapplication.cpp
 
 TRANSLATIONS += $$PWD/translations/$${TARGET}.ts \
     $$PWD/translations/$${TARGET}_zh_CN.ts


### PR DESCRIPTION
  Added detection to ensure that only one custom screensaver process can exist

Log: fix multiple custom screensaver Settings coexist
Bug: https://pms.uniontech.com/bug-view-168293.html