### PR TITLE
fix: Fix that deepin-custom-screensaver not show in wayland

### DIFF
--- a/customscreensaver/deepin-custom-screensaver/src/main.cpp
+++ b/customscreensaver/deepin-custom-screensaver/src/main.cpp
@@ -17,6 +17,7 @@
 #include <QIODevice>
 #include <QTextStream>
 #include <QTimer>
+#include <QDateTime>
 
 #include <X11/Xlib.h>
 
@@ -24,6 +25,12 @@ DWIDGET_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
+    auto envType = qEnvironmentVariable("XDG_SESSION_TYPE");
+    if (envType.contains("wayland")) {
+        qInfo() << QDateTime::currentDateTime().toString() << "notes:change wayland to xcb for QT_QPA_PLATFORM.";
+        qputenv("QT_QPA_PLATFORM", "xcb");
+    }
+
     DApplication a(argc, argv);
     a.setOrganizationName("deepin");
 


### PR DESCRIPTION
 Use the way of X11 to display deepin-custom-screensaver

Log: Fix that deepin-custom-screensaver not show in wayland
Bug: https://pms.uniontech.com/bug-view-170553.html