### PR TITLE
fix: missing window icon.

### DIFF
--- a/src/customconfig.cpp
+++ b/src/customconfig.cpp
@@ -33,6 +33,8 @@ bool CustomConfig::startCustomConfig(const QString &name)
 
     m_settingDialiog = new ScreenSaverSettingDialog(name);
     m_settingDialiog->setAttribute(Qt::WA_DeleteOnClose);
+    // remove dialog flag to let dock show window entry.
+    m_settingDialiog->setWindowFlag(Qt::Dialog, false);
     m_settingDialiog->show();
     m_lastConfigName = name;
     return true;

--- a/src/screensaversettingdialog.cpp
+++ b/src/screensaversettingdialog.cpp
@@ -30,8 +30,9 @@ ScreenSaverSettingDialog::ScreenSaverSettingDialog(const QString &name, QWidget 
 {
     widgetFactory()->registerWidget(SELECTPATHWIDGET, &ScreenSaverSettingDialog::createSelectPathWidget);
     widgetFactory()->registerWidget(TIMEINTERVALWIDGET, &ScreenSaverSettingDialog::createTimeIntervalWidget);
-
-    setIcon(QIcon(":/images/deepin-screensaver-config.svg"));
+    QIcon icon(":/images/deepin-screensaver-config.svg");
+    setIcon(icon);
+    setWindowIcon(icon);
 
     // 加载翻译
     qApp->loadTranslator();


### PR DESCRIPTION
1. Set window icon for ScreenSaverSettingDialog
2. Remove dialog flag to let dock show window entry. 


Log: 

Bug: https://pms.uniontech.com/bug-view-167283.html
Bug: https://pms.uniontech.com/bug-view-167275.html