### PR TITLE
Revert "fix: the idle state dont switch to off when screensaver exite…

### DIFF
--- a/src/dbusscreensaver.cpp
+++ b/src/dbusscreensaver.cpp
@@ -43,11 +43,6 @@
 #   define LOCKFRONT_PATH "/com/deepin/dde/lockFront"
 #endif
 
-static bool isXWayland() {
-    static const bool ret = qEnvironmentVariable("XDG_SESSION_TYPE").contains("wayland");
-    return ret;
-}
-
 struct xcb_screensaver_notify_event
 {
     uint8_t      response_type;
@@ -203,7 +198,8 @@ bool DBusScreenSaver::Preview(const QString &name, int staysOn, bool preview)
 
     emit isRunningChanged(true);
 
-    if (!preview && isXWayland()) {
+    const static bool isWayland = qEnvironmentVariable("XDG_SESSION_TYPE").contains("wayland");
+    if (!preview && isWayland) {
         // 在wayland环境下无法接收到键盘事件，通过强制抓取键盘来进行规避
         qInfo() << QDateTime::currentDateTime().toString() << "current not preview,and wayland is true,grab keyboard!";
         XGrabKeyBoard();
@@ -383,18 +379,6 @@ void DBusScreenSaver::Stop(bool lock)
     }
 
     m_windowMap.clear();
-
-    //reset state
-    if (isXWayland()) {
-        qInfo() << "reset idle by com.deepin.daemon.KWayland";
-        QDBusMessage msg = QDBusMessage::createMethodCall("com.deepin.daemon.KWayland", "/com/deepin/daemon/KWayland/Output",
-                                    "com.deepin.daemon.KWayland.Idle", "simulateUserActivity");
-        QDBusConnection::sessionBus().asyncCall(msg, 5);
-        qInfo() << "call" << msg.path() << msg.interface() << "simulateUserActivity";
-    } else {
-        qInfo() << "reset idle by X";
-        XResetScreenSaver(QX11Info::display());
-    }
 
 #ifndef QT_DEBUG
     m_autoQuitTimer.start();


### PR DESCRIPTION
Revert "fix: the idle state dont switch to off when screensaver exited without input event."

This reverts commit ed5fef13ca36ada83ea76912a4345895581e9595.

Bug: https://pms.uniontech.com/bug-view-214139.html