### PR TITLE
fix: translation file errors

### DIFF
--- a/customscreensaver/deepin-custom-screensaver/src/slideshowconfigdialog.cpp
+++ b/customscreensaver/deepin-custom-screensaver/src/slideshowconfigdialog.cpp
@@ -109,12 +109,12 @@ void SlideShowConfigDialog::initUI()
         bgGroup->setUseWidgetBackground(false);
         contentlayout->addWidget(bgGroup);
 
-        for (QWidget *wid : contWid) {
+        for (QWidget *pwid : contWid) {
             QWidget *wrapperWidget = new QWidget(bgGroup);
             QHBoxLayout *hLay = new QHBoxLayout(wrapperWidget);
             hLay->setContentsMargins(10, 6, 10, 6);
-            wid->setParent(wrapperWidget);
-            hLay->addWidget(wid);
+            pwid->setParent(wrapperWidget);
+            hLay->addWidget(pwid);
 
             bgGpLayout->addWidget(wrapperWidget);
         }
@@ -136,9 +136,12 @@ void SlideShowConfigDialog::initUI()
 
     // reset
     {
+        QSpacerItem *spaceItem = new QSpacerItem(0, 30, QSizePolicy::Minimum,QSizePolicy::Expanding);
+        contentlayout->addItem(spaceItem);
+
         QWidget *box = new QWidget();
         QHBoxLayout *box_layout = new QHBoxLayout(box);
-        box_layout->setContentsMargins(0, 30, 0, 0);
+        box_layout->setContentsMargins(0, 0, 0, 0);
         auto resetBt = new DPushButton(QObject::tr("Restore Defaults"), box);
         resetBt->setMaximumWidth(300);
         resetBt->setAutoDefault(false);

--- a/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver_ug.ts
+++ b/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver_ug.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../src/slideshowconfigdialog.cpp" line="142"/>
         <source>Restore Defaults</source>
-        translation>ئەسلىدىكى تەڭشەك ھالىتىگە قايتۇرۇش</translation>
+        <translation>ئەسلىدىكى تەڭشەك ھالىتىگە قايتۇرۇش</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fix ug translation file formatting error.
Using spacer instead of margins.

Log: 

Bug: https://pms.uniontech.com/bug-view-239897.html
Bug: https://pms.uniontech.com/bug-view-239889.html
