### PR TITLE
fix: 【文件管理器】自定义屏保缩略图及右键菜单中菜单命令未国际化,展示为英文

### DIFF
--- a/customscreensaver/deepin-custom-screensaver/src/main.cpp
+++ b/customscreensaver/deepin-custom-screensaver/src/main.cpp
@@ -34,7 +34,8 @@ int main(int argc, char *argv[])
     DApplication a(argc, argv);
     a.setOrganizationName("deepin");
     a.loadTranslator();
-
+    a.setApplicationName(QObject::tr("deepin-screensaver"));
+    a.setApplicationDisplayName(QObject::tr("deepin-screensaver"));
     CommandLineManager::instance()->process(a.arguments());
 
     if (CommandLineManager::instance()->isSet("window-id")) {

--- a/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver.ts
+++ b/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver.ts
@@ -8,6 +8,16 @@
         <source>Restore Defaults</source>
         <translation>Restore Defaults</translation>
     </message>
+    <message>
+        <location filename="../src/main.cpp" line="37"/>
+        <source>deepin-screensaver</source>
+        <translation>自定义屏保</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="38"/>
+        <source>123</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SelectPathWidget</name>

--- a/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver_zh_CN.ts
+++ b/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver_zh_CN.ts
@@ -8,6 +8,12 @@
         <source>Restore Defaults</source>
         <translation>恢复默认</translation>
     </message>
+    <message>
+        <location filename="../src/main.cpp" line="37"/>
+        <location filename="../src/main.cpp" line="38"/>
+        <source>deepin-screensaver</source>
+        <translation>自定义屏保设置</translation>
+    </message>
 </context>
 <context>
     <name>SelectPathWidget</name>


### PR DESCRIPTION
修改了【文件管理器】自定义屏保缩略图及右键菜单中菜单命令未国际化,展示为英文

Log: 修改了【文件管理器】自定义屏保缩略图及右键菜单中菜单命令未国际化,展示为英文

Bug: https://pms.uniontech.com/bug-view-263945.html