### PR TITLE
fix: The custom screensaver thumbnail and menu commands in the right-click menu are not internationalized and are displayed in English

### DIFF
--- a/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver.ts
+++ b/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver.ts
@@ -10,13 +10,9 @@
     </message>
     <message>
         <location filename="../src/main.cpp" line="37"/>
+        <location filename="../src/main.cpp" line="38"/>
         <source>deepin-screensaver</source>
         <translation>自定义屏保</translation>
-    </message>
-    <message>
-        <location filename="../src/main.cpp" line="38"/>
-        <source>123</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver_zh_CN.ts
+++ b/customscreensaver/deepin-custom-screensaver/translations/deepin-custom-screensaver_zh_CN.ts
@@ -12,7 +12,7 @@
         <location filename="../src/main.cpp" line="37"/>
         <location filename="../src/main.cpp" line="38"/>
         <source>deepin-screensaver</source>
-        <translation>自定义屏保设置</translation>
+        <translation>自定义屏保</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
fix: The custom screensaver thumbnail and menu commands in the right-click menu are not internationalized and are displayed in English

the custom screensaver thumbnail and menu commands in the right-click menu are not internationalized and are displayed in English

Log: The custom screensaver thumbnail and menu commands in the right- click menu are not internationalized and are displayed in English

Bug: https://pms.uniontech.com/bug-view-263945.html