### PR TITLE
fix: fix the issue of not being able to find qlocalserver. h in 1053CRP packaging

### DIFF
--- a/customscreensaver/deepin-custom-screensaver/deepin-custom-screensaver.pro
+++ b/customscreensaver/deepin-custom-screensaver/deepin-custom-screensaver.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui dtkcore
+QT       += core gui dtkcore network
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 

--- a/customscreensaver/deepin-custom-screensaver/src/singleinstance.cpp
+++ b/customscreensaver/deepin-custom-screensaver/src/singleinstance.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "singleinstance.h"
-
+#include <QtNetwork/qlocalserver.h>
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QStandardPaths>


### PR DESCRIPTION
fix: fix the issue of not being able to find qlocalserver. h in 1053CRP packaging

Fix the issue of not being able to find
qlocalserver. h in 1053CRP packaging

Log: fix the issue of not being able to find
    qlocalserver. h in 1053CRP packaginging

Bug: https://pms.uniontech.com/bug-view-269749.html