### PR TITLE
fix: [ui]adjust layout margin for restore defaults button 

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -29,7 +29,7 @@ Copyright: UnionTech Software Technology Co., Ltd.
 License: CC0-1.0
 
 # Project file
-Files: *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/*
+Files: *.project *.pro *.prf *.pri *.qrc *CMakeLists.txt .tx/*
 Copyright: None
 License: CC0-1.0
 

--- a/customscreensaver/deepin-custom-screensaver/src/slideshowconfigdialog.cpp
+++ b/customscreensaver/deepin-custom-screensaver/src/slideshowconfigdialog.cpp
@@ -141,7 +141,7 @@ void SlideShowConfigDialog::initUI()
 
         QWidget *box = new QWidget();
         QHBoxLayout *box_layout = new QHBoxLayout(box);
-        box_layout->setContentsMargins(0, 0, 0, 0);
+        box_layout->setContentsMargins(0, 0, 0, 10);
         auto resetBt = new DPushButton(QObject::tr("Restore Defaults"), box);
         resetBt->setMaximumWidth(300);
         resetBt->setAutoDefault(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,12 @@
 #include <QCommandLineOption>
 #include <QDateTime>
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#    include "screensaver_adaptor.h"
+#else
 #include "screensaveradaptor.h"
+#endif
+
 #include "dbusscreensaver.h"
 #include "customconfig.h"
 #include "commandlinehelper.h"


### PR DESCRIPTION
- Add 10 pixels margin to the bottom of the layout containing the restore defaults button

Log: [ui]adjust layout margin for restore defaults button
Bug: https://pms.uniontech.com/bug-view-251759.html