### PR TITLE
chore: switch to qt6 for debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 set(LIB_PATH "${CMAKE_INSTALL_PREFIX}/lib/deepin-screensaver" CACHE PATH "Library installation path")
 set(MODULE_PATH "${LIB_PATH}/modules" CACHE PATH "Module installation path")
 set(RESOURCE_PATH "${LIB_PATH}/resources" CACHE PATH "Resource installation path")
+set(QT_VERSION_MAJOR "6" CACHE STRING "Build with qt version major")
 
 add_definitions(-DLIB_PATH="${LIB_PATH}" -DMODULE_PATH="${MODULE_PATH}" -DRESOURCE_PATH="${RESOURCE_PATH}")
 
@@ -20,14 +21,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 # 引入翻译生成
 include(translation-generate)
 
-# 查找 Qt 版本
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
-message("   >>> Found Qt version: ${QT_VERSION_MAJOR}")
-set(QT_DESIRED_VERSION ${QT_VERSION_MAJOR})
-
-if (QT_VERSION_MAJOR MATCHES 6)
-    set(DTK_VERSION_MAJOR 6)
+if (QT_VERSION_MAJOR STREQUAL "6")
+    set(QT_VERSION_MAJOR "6")
+    set(QT_DESIRED_VERSION "6")
+    set(DTK_VERSION_MAJOR "6")
 else()
+    set(QT_VERSION_MAJOR "5")
+    set(QT_DESIRED_VERSION "5")
     set(DTK_VERSION_MAJOR "")
 endif()
 message("   >>> Build with DTK: ${DTK_VERSION_MAJOR}")

--- a/debian/rules
+++ b/debian/rules
@@ -7,8 +7,10 @@ include /usr/share/dpkg/default.mk
 define detect_qt_version
 ifneq (,$(shell which qmake6 2>/dev/null))
     QT_DIR="/usr/lib/$(DEB_HOST_MULTIARCH)/cmake/Qt6"
+    QT_VERSION_MAJOR="6"
 else
     QT_DIR="/usr/lib/$(DEB_HOST_MULTIARCH)/cmake/Qt5"
+    QT_VERSION_MAJOR="5"
 endif
 endef
 
@@ -30,4 +32,5 @@ override_dh_auto_configure:
 	-DCMAKE_INSTALL_PREFIX=/usr \
 	-DAPP_VERSION=$(DEB_VERSION_UPSTREAM) -DVERSION=$(DEB_VERSION_UPSTREAM) \
 	-DLIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) \
-	-DQT_DIR=$(QT_DIR)
+	-DQT_DIR=$(QT_DIR) \
+	-DQT_VERSION_MAJOR=$(QT_VERSION_MAJOR)


### PR DESCRIPTION
`find_package(QT NAMES Qt6 Qt5)` always get qt5.
We add QT_VERSION_MAJOR option.
