### PR TITLE
chore: bump version to 6.5.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-screensaver (6.5.1) unstable; urgency=medium
+
+  * chore: switch to qt6 for debian
+  * fix: [ui] Solve the scaling problem
+  * fix: [ui]adjust layout margin for restore defaults button
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 17 Apr 2025 20:20:11 +0800
+
 deepin-screensaver (6.5.0) unstable; urgency=medium
 
   * Update version to 6.5.0.


### PR DESCRIPTION
update changelog to 6.5.1