### PR TITLE
feat: implement automatic DBus property change notifications

### DIFF
--- a/src/dbusscreensaver.h
+++ b/src/dbusscreensaver.h
@@ -35,6 +35,8 @@ public:
     explicit DBusScreenSaver(QObject *parent = nullptr);
     ~DBusScreenSaver();
 
+    bool setProperty(const char *name, const QVariant &value);
+
     bool Preview(const QString &name, int staysOn = 1, bool preview = true);
     QString GetScreenSaverCover(const QString &name) const;
     void RefreshScreenSaverList();
@@ -60,6 +62,7 @@ public:
     bool StartCustomConfig(const QString &name);
     QStringList ConfigurableItems();
     bool IsConfigurable(const QString &name);
+
 signals:
     void allScreenSaverChanged(QStringList allScreenSaver);
     void batteryScreenSaverTimeoutChanged(int batteryScreenSaverTimeout);
@@ -83,6 +86,9 @@ private:
     void XUnGrabKeyBoard();
     void onLockedChanged(const bool locked);
 
+    // 统一的 DBus 属性变化信号发送方法
+    void sendDBusPropertyChanged(const QString &propertyName, const QVariant &value);
+
     QList<QDir> m_resourceDirList;
     QStringList m_resourceList;
 
@@ -103,6 +109,8 @@ private:
 
     DConfig *m_dcfg;
     QScopedPointer<QDBusInterface> m_powerInterface;
+
+    static const QStringList m_dbusProperties;
 };
 
 #endif // DBUSSCREENSAVER_H


### PR DESCRIPTION
1. Added QDBusMessage include for DBus communication
2. Created static list of DBus properties that need notifications
3. Overrode setProperty to automatically send PropertiesChanged signals
4. Implemented sendDBusPropertyChanged helper method
5. Added debug logging for property changes
6. This ensures DBus clients are immediately notified of property changes

The changes improve the DBus interface by automatically notifying clients when important properties change, rather than requiring manual signal emission. This makes the API more consistent and reliable for clients monitoring property changes.

feat: 实现自动 DBus 属性变更通知

1. 添加 QDBusMessage 头文件用于 DBus 通信
2. 创建需要通知的 DBus 属性静态列表
3. 重写 setProperty 方法自动发送 PropertiesChanged 信号
4. 实现 sendDBusPropertyChanged 辅助方法
5. 添加属性变更的调试日志
6. 确保 DBus 客户端能立即收到属性变更通知

这些改进通过自动通知客户端重要属性变更，使 DBus 接口更加完善，不再需要手
动触发信号。这使得监控属性变更的客户端 API 更加一致可靠。

pms: BUG-316495