### PR TITLE
fix: include QEvent for dbusscreensaver build failure

### DIFF
--- a/src/dbusscreensaver.h
+++ b/src/dbusscreensaver.h
@@ -7,6 +7,7 @@
 
 #include <DConfig>
 
+#include <QEvent>
 #include <QObject>
 #include <QDir>
 #include <QTimer>


### PR DESCRIPTION
dbusscreensaver.h declares onInputEventReceived(QEvent::Type), but does not include QEvent. This fixes the Arch build error: 'QEvent::Type' has not been declared.